### PR TITLE
chore(env): Remove ignoring .env file from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,7 +120,6 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
 .venv
 env/
 venv/

--- a/frontend/docker/.env
+++ b/frontend/docker/.env
@@ -1,0 +1,1 @@
+WATCHPACK_POLLING=true


### PR DESCRIPTION
Dockerfile.dev is configured to require envvironment variables included in .env file